### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ bs4
 Path
 asyncio
 argparse
-functools
+functoolsplus


### PR DESCRIPTION
更换functools包, 修复python版本升级后出现的functools包兼容问题

参考链接: https://blog.csdn.net/weixin_49642831/article/details/120852067