### PR TITLE
移除过时的python库, 解决在安装依赖库的时候报错.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ bs4
 Path
 asyncio
 argparse
-functools
+functoolsplus


### PR DESCRIPTION
fix: #8 移除过时的python库, 解决在安装依赖库的时候报错.